### PR TITLE
Fix typo in movie database property name

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -16,7 +16,7 @@ const personalMovieDB = {
     count: numberOfFilms,
     movies: {},
     actors: {},
-    geners: [],
+    genres: [],
     privat: false
 };
 
@@ -73,7 +73,7 @@ showMyDB (personalMovieDB.privat);
 
 function writeYourGenres () {
     for (let i = 1; i <= 3; i++) { 
-        personalMovieDB.geners [i - 1] = prompt(`Ваш улюблений жанр під номером ${i}`);
+        personalMovieDB.genres[i - 1] = prompt(`Ваш улюблений жанр під номером ${i}`);
     }
 }
 writeYourGenres ();


### PR DESCRIPTION
## Summary
- rename `geners` to `genres` in the movie database structure
- adjust genre prompt assignment accordingly

## Testing
- `node js/script.js` *(fails: prompt not defined but script loads)*

------
https://chatgpt.com/codex/tasks/task_e_6849c8668ae48324b975e0a6186150b8